### PR TITLE
extract_char 수정 (flag 추가) - 251109

### DIFF
--- a/include/handler.h
+++ b/include/handler.h
@@ -57,7 +57,7 @@ struct obj_data *get_obj_in_list_vis(struct char_data *ch, char *name,
 				     struct obj_data *list);
 struct obj_data *get_obj_vis(struct char_data *ch, char *name);
 
-void extract_char(struct char_data *ch);
+void extract_char(struct char_data *ch, int drop_items);
 
 /* Generic Find */
 

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -2092,7 +2092,7 @@ void do_police(struct char_data *ch, char *argument, int cmd)
 						wipe_obj(d->character->carrying);
 					d->character->carrying = 0;
 					close_socket(d);
-					extract_char(d->character);
+					extract_char(d->character, TRUE);
 				}
 			} else {
 				close_socket(d);

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -74,7 +74,7 @@ void do_quit(struct char_data *ch, char *argument, int cmd)
 	log(cyb);
 	if (ch->desc)
 		close_socket(ch->desc);
-	extract_char(ch);
+	extract_char(ch, FALSE);
 }
 
 void do_wimpy(struct char_data *ch, char *argument, int cmd)

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -986,12 +986,12 @@ void do_purge(struct char_data *ch, char *argument, int cmd)
 				vict->carrying = 0;
 				if (vict->desc)
 					close_socket(vict->desc);
-				extract_char(vict);
+				extract_char(vict, TRUE);
 				return;
 			}
 			act("$n disintegrates $N.", FALSE, ch, 0, vict, TO_NOTVICT);
 			if (IS_NPC(vict)) {
-				extract_char(vict);
+				extract_char(vict, TRUE);
 			}
 		} else if ((obj = get_obj_in_list_vis(ch, name,
 						      world[ch->in_room].contents))) {
@@ -1013,7 +1013,7 @@ void do_purge(struct char_data *ch, char *argument, int cmd)
 		for (vict = world[ch->in_room].people; vict; vict = next_v) {
 			next_v = vict->next_in_room;
 			if (IS_NPC(vict))
-				extract_char(vict);
+				extract_char(vict, TRUE);
 		}
 		for (obj = world[ch->in_room].contents; obj; obj = next_o) {
 			next_o = obj->next_content;

--- a/src/db.c
+++ b/src/db.c
@@ -3535,7 +3535,7 @@ void do_rent(struct char_data *ch, int cmd, char *arg)
 	wipe_obj(ch->carrying);
 	ch->carrying = 0;
 	// save_room = ch->in_room;
-	extract_char(ch);
+	extract_char(ch, TRUE);
 /*
 	ch->in_room = world[save_room].number;
 	save_char(ch, ch->in_room);

--- a/src/fight.c
+++ b/src/fight.c
@@ -379,7 +379,7 @@ void raw_kill(struct char_data *ch, int level)
 
 	death_cry(ch);
 	make_corpse(ch, level);
-	extract_char(ch);
+	extract_char(ch, TRUE);
 }
 
 void die(struct char_data *ch, int level, struct char_data *who)

--- a/src/gbisland.c
+++ b/src/gbisland.c
@@ -65,27 +65,20 @@ void gbisland_move_seashore(struct char_data *ch)
 	send_to_char(".........\n\r", ch);
 	send_to_char(".........\n\r", ch);
 	send_to_char(".........\n\r", ch);
-	send_to_char
-	    ("빗방울이 굵어 지더니 배가 심하게 흔들립니다.\n\r", ch);
-	send_to_char
-	    ("당신은 배의 난간을 잡고 힘껏 버티어 봅니다.\n\r", ch);
-	send_to_char
-	    ("난간이 부서져 나가고 당신은 배의 반대쪽으로 쓰러져 갑니다.\n\r", ch);
+	send_to_char("빗방울이 굵어 지더니 배가 심하게 흔들립니다.\n\r", ch);
+	send_to_char("당신은 배의 난간을 잡고 힘껏 버티어 봅니다.\n\r", ch);
+	send_to_char("난간이 부서져 나가고 당신은 배의 반대쪽으로 쓰러져 갑니다.\n\r", ch);
 	send_to_char(".........\n\r", ch);
 	send_to_char(".........\n\r", ch);
-	send_to_char
-	    ("설상가상으로 멀리 소용돌이가 보입니다.\n\r", ch);
-	send_to_char
-	    ("당신은 당신의 배와 함께 소용돌이로 빨려들어갑니다.\n\r", ch);
+	send_to_char("설상가상으로 멀리 소용돌이가 보입니다.\n\r", ch);
+	send_to_char("당신은 당신의 배와 함께 소용돌이로 빨려들어갑니다.\n\r", ch);
 	send_to_char(".........\n\r", ch);
 	send_to_char(".........\n\r", ch);
 	send_to_char(".........\n\r", ch);
-	send_to_char
-	    ("소용돌이의 힘에 배가 부서지고, 당신은 바다로 내동댕이 쳐 집니다.\n\r", ch);
+	send_to_char("소용돌이의 힘에 배가 부서지고, 당신은 바다로 내동댕이 쳐 집니다.\n\r", ch);
 	send_to_char(".........\n\r", ch);
-	send_to_char
-	    ("헤엄을 잘치는 당신이지만 소용돌이의 힘에서는 어쩔수 없습니다.\n\r", ch);
-	send_to_char("당신은 점차로 의식을 일어갑니다.\n\r", ch);
+	send_to_char("수영을 잘하는 당신이지만 소용돌이의 힘 앞에서는 어쩔수 없습니다.\n\r", ch);
+	send_to_char("당신은 점차로 의식을 잃어갑니다.\n\r", ch);
 	send_to_char(".........\n\r", ch);
 	send_to_char("으~~~\n\r", ch);
 	send_to_char("으~~\n\r", ch);
@@ -118,8 +111,7 @@ void gbisland_move_seashore(struct char_data *ch)
 
 	/* check - remortal */
 	if ((ch->player.remortal < 15) && (GET_LEVEL(ch) < IMO)) {
-		send_to_char
-		    ("당신은 소용돌이에 휘말려 정신을 차리지 못합니다.\n\r", ch);
+		send_to_char("당신은 소용돌이에 휘말려 정신을 차리지 못합니다.\n\r", ch);
 		send_to_char("당신은 죽습니다.\n\r", ch);
 
 		wipe_stash(GET_NAME(ch));
@@ -451,7 +443,7 @@ int gbisland_lanessa(struct char_data *ch, int cmd, char *arg)
 
 				obj_to_room(obj, ch->in_room);
 
-				extract_char(ch);
+				extract_char(ch, TRUE);
 			} else if (paper1 || paper2) {
 				do_say(ch,
 				       "다른 부분도 마저 찾아 주세요...", 0);

--- a/src/mabact.c
+++ b/src/mabact.c
@@ -124,7 +124,7 @@ void mobile_activity(void)
 		if (mob_index[ch->nr].virtual == SON_OGONG_MIRROR) {
 			(ch->quest.solved)++;
 			if (ch->quest.solved > 50) {
-				extract_char(ch);
+				extract_char(ch, TRUE);
 			}
 		}
 		ch = tmp_ch;

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -40,7 +40,7 @@ int finisher(struct char_data *ch, int cmd, char *arg);
 int warrior(struct char_data *ch, int cmd, char *arg);
 void first_attack(struct char_data *ch, struct char_data *victim);
 void do_cast(struct char_data *ch, char *arg, int cmd);
-void extract_char(struct char_data *ch);
+void extract_char(struct char_data *ch, int drop_items);
 
 int check_stat(struct char_data *ch)
 {
@@ -125,7 +125,7 @@ void mobile_activity(void)
 		if (mob_index[ch->nr].virtual == SON_OGONG_MIRROR) {
 			(ch->quest.solved)++;
 			if (ch->quest.solved > 50) {
-				extract_char(ch);
+				extract_char(ch, TRUE);
 			}
 		}
 		ch = tmp_ch;


### PR DESCRIPTION
** do_quit()의 아이템 복사 현상 수정 시도 ** 
extract_char 함수를 수정해 drop_items 플래그를 확인하도록 했습니다.
기존에 ch만 인수로 전달하던 것을 extract_char(ch, flag) 형태로 전달합니다.
extract_char가 사용된 기존 코드를 같이 수정했습니다.
- 기존 사용처는 모두 TRUE, do_quit 내부에서 FALSE로 호출